### PR TITLE
MaterialSerializer: remove unnecessary check

### DIFF
--- a/OgreMain/src/OgreMaterialSerializer.cpp
+++ b/OgreMain/src/OgreMaterialSerializer.cpp
@@ -187,9 +187,6 @@ namespace Ogre
             // Iterate over techniques
             for(auto t : pMat->getTechniques())
             {
-                // skip RTSS generated techniques
-                if(!mDefaults && t->getSchemeName() == "ShaderGeneratorDefaultScheme")
-                    continue;
                 writeTechnique(t);
                 mBuffer += "\n";
             }


### PR DESCRIPTION
it was preventing us from saving legacy materials